### PR TITLE
Observing (was: subscription)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,8 +1342,8 @@
       "dev": true
     },
     "discipl-core-baseconnector": {
-      "version": "git+https://github.com/discipl/discipl-core-baseconnector.git#5336e0db4a14ac06cd0b1b8b93b2c2815049d548",
-      "from": "git+https://github.com/discipl/discipl-core-baseconnector.git"
+      "version": "git+https://github.com/discipl/discipl-core-baseconnector.git#35eed39e24d5228e44d94ba00a12668b743e716d",
+      "from": "git+https://github.com/discipl/discipl-core-baseconnector.git#feature/observe"
     },
     "doctrine": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,8 +1342,8 @@
       "dev": true
     },
     "discipl-core-baseconnector": {
-      "version": "git+https://github.com/discipl/discipl-core-baseconnector.git#0980dcc053b90237ccec3ded30fa845cefd8fba2",
-      "from": "git+https://github.com/discipl/discipl-core-baseconnector.git#refactor/es6-and-quality"
+      "version": "git+https://github.com/discipl/discipl-core-baseconnector.git#5336e0db4a14ac06cd0b1b8b93b2c2815049d548",
+      "from": "git+https://github.com/discipl/discipl-core-baseconnector.git"
     },
     "doctrine": {
       "version": "2.1.0",
@@ -4402,12 +4402,11 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -4727,6 +4726,17 @@
             "string-width": "^2.1.0",
             "strip-ansi": "^4.0.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "5.5.12",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+              "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+              "dev": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            }
           }
         },
         "json-schema-traverse": {
@@ -4928,8 +4938,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "crypto-js": "3.1.9-1",
-    "discipl-core-baseconnector": "git+https://github.com/discipl/discipl-core-baseconnector.git",
+    "discipl-core-baseconnector": "git+https://github.com/discipl/discipl-core-baseconnector.git#feature/observe",
     "rxjs": "^6.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "crypto-js": "3.1.9-1",
-    "discipl-core-baseconnector": "git+https://github.com/discipl/discipl-core-baseconnector.git"
+    "discipl-core-baseconnector": "git+https://github.com/discipl/discipl-core-baseconnector.git",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,16 @@ class LocalMemoryConnector extends BaseConnector {
     }
   }
 
-  async subscribe (ssid, claimFilter) {
+  /**
+   * Observes the stream of claims from the memory connector
+   *
+   * @param ssid {object} ssid that the claims should come frome
+   * @param ssid.pubkey {string} Only property of ssid that is matched on
+   * @param claimFilter {object} Object resembling a claim. The key-value pairs must match the claim,
+   * unless the value is null, in which case the key must be present
+   * @returns {Promise<Observable<any>>} Observable that must be subscribed to before any claims are actually captured.
+   */
+  async observe (ssid, claimFilter) {
     return this.claimSubject.pipe(filter(claim => {
       if (claimFilter != null) {
         for (let predicate of Object.keys(claimFilter)) {

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class LocalMemoryConnector extends BaseConnector {
       this.storeData[ssid.pubkey]['claims'][index] = { 'data': data, 'previous': this.storeData[ssid.pubkey]['lastClaim'] }
 
       this.storeData[ssid.pubkey]['lastClaim'] = index
-      this.claimSubject.next({ 'pubkey': ssid.pubkey, 'claim': this.storeData[ssid.pubkey]['claims'][index] })
+      this.claimSubject.next({ 'ssid': { 'pubkey': ssid.pubkey }, 'claim': this.storeData[ssid.pubkey]['claims'][index] })
       return index
     }
     return null
@@ -66,19 +66,19 @@ class LocalMemoryConnector extends BaseConnector {
     return this.claimSubject.pipe(filter(claim => {
       if (claimFilter != null) {
         for (let predicate of Object.keys(claimFilter)) {
-          if (claim[predicate] == null) {
+          if (claim['claim']['data'][predicate] == null) {
             // Predicate not present in claim
             return false
           }
 
-          if (claimFilter[predicate] != null && claimFilter[predicate] !== claim[predicate]) {
+          if (claimFilter[predicate] != null && claimFilter[predicate] !== claim['claim']['data'][predicate]) {
             // Object is provided in filter, but does not match with actual claim
             return false
           }
         }
       }
 
-      return ssid != null && claim.pubkey === ssid.pubkey
+      return ssid == null || claim.ssid.pubkey === ssid.pubkey
     })
     )
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,8 @@
 import { expect } from 'chai'
 import MemoryConnector from '../src/index'
 
+import { take } from 'rxjs/operators'
+
 describe('disciple-memory-connector', () => {
   it('should present a name', async () => {
     let memoryConnector = new MemoryConnector()
@@ -118,13 +120,16 @@ describe('disciple-memory-connector', () => {
     expect(verification).to.equal(null)
   })
 
-  it('should not support subscribe', () => {
+  it('be able to subscribe', async () => {
     let memoryConnector = new MemoryConnector()
-    return memoryConnector.subscribe(null)
-      .then((result) => expect.fail('Should not have succeeded'))
-      .catch((error) => {
-        expect(error).to.be.an('error')
-        expect(error.message).to.equal('Subscribe is not implemented')
-      })
+    let ssid = await memoryConnector.newSsid()
+
+    let observable = await memoryConnector.subscribe(ssid)
+    let resultPromise = observable.pipe(take(1)).toPromise()
+    await memoryConnector.claim(ssid, { 'need': 'beer' })
+
+    let result = await resultPromise
+
+    expect(result).to.deep.equal({})
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -130,6 +130,89 @@ describe('disciple-memory-connector', () => {
 
     let result = await resultPromise
 
-    expect(result).to.deep.equal({})
+    expect(result).to.deep.equal({
+      'claim': {
+        'data': {
+          'need': 'beer'
+        },
+        'previous': null
+      },
+      'ssid': {
+        'pubkey': ssid.pubkey
+      }
+    })
+  })
+
+  it('be able to subscribe without an ssid', async () => {
+    let memoryConnector = new MemoryConnector()
+    let ssid = await memoryConnector.newSsid()
+
+    let observable = await memoryConnector.subscribe(null)
+    let resultPromise = observable.pipe(take(1)).toPromise()
+    await memoryConnector.claim(ssid, { 'need': 'beer' })
+
+    let result = await resultPromise
+
+    expect(result).to.deep.equal({
+      'claim': {
+        'data': {
+          'need': 'beer'
+        },
+        'previous': null
+      },
+      'ssid': {
+        'pubkey': ssid.pubkey
+      }
+    })
+  })
+
+  it('be able to subscribe with a filter', async () => {
+    let memoryConnector = new MemoryConnector()
+    let ssid = await memoryConnector.newSsid()
+
+    let observable = await memoryConnector.subscribe(null, { 'need': 'wine' })
+    let resultPromise = observable.pipe(take(1)).toPromise()
+    let previousLink = await memoryConnector.claim(ssid, { 'need': 'beer' })
+    await memoryConnector.claim(ssid, { 'need': 'wine' })
+    await memoryConnector.claim(ssid, { 'need': 'tea' })
+
+    let result = await resultPromise
+
+    expect(result).to.deep.equal({
+      'claim': {
+        'data': {
+          'need': 'wine'
+        },
+        'previous': previousLink
+      },
+      'ssid': {
+        'pubkey': ssid.pubkey
+      }
+    })
+  })
+
+  it('be able to subscribe with a filter on the predicate', async () => {
+    let memoryConnector = new MemoryConnector()
+    let ssid = await memoryConnector.newSsid()
+
+    let observable = await memoryConnector.subscribe(null, { 'desire': null })
+    let resultPromise = observable.pipe(take(1)).toPromise()
+    let previousLink = await memoryConnector.claim(ssid, { 'need': 'beer' })
+    await memoryConnector.claim(ssid, { 'desire': 'wine' })
+    await memoryConnector.claim(ssid, { 'need': 'tea' })
+
+    let result = await resultPromise
+
+    expect(result).to.deep.equal({
+      'claim': {
+        'data': {
+          'desire': 'wine'
+        },
+        'previous': previousLink
+      },
+      'ssid': {
+        'pubkey': ssid.pubkey
+      }
+    })
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -120,11 +120,11 @@ describe('disciple-memory-connector', () => {
     expect(verification).to.equal(null)
   })
 
-  it('be able to subscribe', async () => {
+  it('be able to observe', async () => {
     let memoryConnector = new MemoryConnector()
     let ssid = await memoryConnector.newSsid()
 
-    let observable = await memoryConnector.subscribe(ssid)
+    let observable = await memoryConnector.observe(ssid)
     let resultPromise = observable.pipe(take(1)).toPromise()
     await memoryConnector.claim(ssid, { 'need': 'beer' })
 
@@ -143,11 +143,11 @@ describe('disciple-memory-connector', () => {
     })
   })
 
-  it('be able to subscribe without an ssid', async () => {
+  it('be able to observe without an ssid', async () => {
     let memoryConnector = new MemoryConnector()
     let ssid = await memoryConnector.newSsid()
 
-    let observable = await memoryConnector.subscribe(null)
+    let observable = await memoryConnector.observe(null)
     let resultPromise = observable.pipe(take(1)).toPromise()
     await memoryConnector.claim(ssid, { 'need': 'beer' })
 
@@ -166,11 +166,11 @@ describe('disciple-memory-connector', () => {
     })
   })
 
-  it('be able to subscribe with a filter', async () => {
+  it('be able to observe with a filter', async () => {
     let memoryConnector = new MemoryConnector()
     let ssid = await memoryConnector.newSsid()
 
-    let observable = await memoryConnector.subscribe(null, { 'need': 'wine' })
+    let observable = await memoryConnector.observe(null, { 'need': 'wine' })
     let resultPromise = observable.pipe(take(1)).toPromise()
     let previousLink = await memoryConnector.claim(ssid, { 'need': 'beer' })
     await memoryConnector.claim(ssid, { 'need': 'wine' })
@@ -191,11 +191,11 @@ describe('disciple-memory-connector', () => {
     })
   })
 
-  it('be able to subscribe with a filter on the predicate', async () => {
+  it('be able to observe with a filter on the predicate', async () => {
     let memoryConnector = new MemoryConnector()
     let ssid = await memoryConnector.newSsid()
 
-    let observable = await memoryConnector.subscribe(null, { 'desire': null })
+    let observable = await memoryConnector.observe(null, { 'desire': null })
     let resultPromise = observable.pipe(take(1)).toPromise()
     let previousLink = await memoryConnector.claim(ssid, { 'need': 'beer' })
     await memoryConnector.claim(ssid, { 'desire': 'wine' })


### PR DESCRIPTION
This implements what used to be the subscribe method for the memory connector.

I renamed this to observe, because it returns an observable that must be subscribed to before any actual effect happens. This is more in line with rxjs terminology. 

The alternative would be to accept a callback function and do the actual subscribe in the function, but I think this is a cleaner interface and seems more in line with the intended use.